### PR TITLE
in-app test code editing

### DIFF
--- a/electron/css/dataproofer.css
+++ b/electron/css/dataproofer.css
@@ -85,7 +85,6 @@ Navigation buttons
 }
 #forward-button {
   background-color: #ED4224;
-
 }
 
 
@@ -235,6 +234,68 @@ button.run-tests {
   color: white;
   font-size: 24px;
   padding: 1em;
+}
+
+.test-editor {
+  position: fixed;
+  top: 87px;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
+  border-top: 4px solid #777;
+  background-color: rgba(255, 255, 255, 0.95);
+}
+.test-editor h3 {
+  margin-left: 20px;
+}
+.test-editor input {
+  margin: 20px;
+  border: none;
+  border-bottom: 2px solid white;
+  padding: 3px;
+  outline: none;
+  width: 80%;
+}
+#test-editor-name {
+  font-size: 20px;
+}
+#test-editor-description {
+  font-size: 14px;
+}
+.test-editor input:focus {
+  border-bottom: 2px solid #333;
+}
+#test-editor-js {
+  display: block;
+  margin-left: 20px;
+  width: 100%;
+  height: calc(100% - 250px);
+}
+.CodeMirror {
+  width: 100%;
+  height: 100%;
+}
+
+.test-editor button {
+  display: inline-block;
+  font-size: 16px;
+  border: 0;
+  padding: 0.5em;
+  margin-bottom: 2px;
+  margin-right: 2px;
+  margin-left: 20px;
+  margin-top: 10px;
+  outline: none;
+}
+.test-editor button:hover {
+  box-shadow: 3px 3px 6px #999;
+}
+#cancel-test {
+  background-color: #ccc;
+}
+#save-test {
+  background-color: #ED4224;
+  color: white;
 }
 
 /* =============================================================================
@@ -388,7 +449,7 @@ General Suites and test
 }
 
 .suite .test .onoff {
-  
+
 }
 
 .suite .test.active {

--- a/electron/css/dataproofer.css
+++ b/electron/css/dataproofer.css
@@ -238,11 +238,11 @@ button.run-tests {
 
 .test-editor {
   position: fixed;
-  top: 87px;
+  /*top: 87px;*/
+  top: 0;
   bottom: 0px;
   left: 0px;
   right: 0px;
-  border-top: 4px solid #777;
   background-color: rgba(255, 255, 255, 0.95);
 }
 .test-editor h3 {
@@ -278,6 +278,7 @@ button.run-tests {
 
 .test-editor button {
   display: inline-block;
+  float: left;
   font-size: 16px;
   border: 0;
   padding: 0.5em;
@@ -294,8 +295,13 @@ button.run-tests {
   background-color: #ccc;
 }
 #save-test {
+  margin-left: 10px;
   background-color: #ED4224;
   color: white;
+}
+#copy-test {
+  margin-left: 10px;
+  background-color: #7fc;
 }
 
 /* =============================================================================

--- a/electron/index.html
+++ b/electron/index.html
@@ -74,9 +74,9 @@
             <input id="test-editor-description" placeholder="Short description of test">
             <br>
             <div id="test-editor-js"></div>
-
-            <button id="cancel-test" class="btn btn-large">Cancel</button>
-            <button id="save-test" style="display: none;" class="btn btn-large">Save</button>
+            <button id="cancel-test">Cancel</button>
+            <button id="copy-test">Copy</button>
+            <button id="save-test" style="display: none;">Save</button>
           </div>
 
         </div>

--- a/electron/index.html
+++ b/electron/index.html
@@ -5,10 +5,11 @@
     <title>Data Proofer</title>
 
     <!-- Stylesheets -->
-    <!-- <link rel="stylesheet" href="node_modules/slickgrid/grid.css"> -->
     <link rel="stylesheet" href="node_modules/handsontable/dist/handsontable.full.css">
-    <!-- <link rel="stylesheet" href="node_modules/slickgrid/css/smoothness/jquery-ui-1.8.16.custom.css" type="text/css"/> -->
+    <link rel="stylesheet" href="node_modules/codemirror/lib/codemirror.css">
+    <link rel="stylesheet" href="node_modules/codemirror/theme/mdn-like.css">
     <link rel="stylesheet" href="css/dataproofer.css">
+
   </head>
   <body>
     <div class="window">
@@ -54,7 +55,6 @@
             <h2 class="title">Step 2: Select tests</h5>
             <!-- we will insert our test suites here -->
             <div class="step-2-select-content">
-
             </div>
 
             <button class="btn btn-large run-tests">Run tests</button>
@@ -67,12 +67,26 @@
           <div id="grid-wrapper">
             <div id="grid" class="spreadsheet"></div>
           </div>
+          <div class="test-editor" style="display:none">
+            <h3>Editing test:</h3>
+            <input id="test-editor-name" placeholder="Name of test">
+            <br>
+            <input id="test-editor-description" placeholder="Short description of test">
+            <br>
+            <div id="test-editor-js"></div>
+
+            <button id="cancel-test" class="btn btn-large">Cancel</button>
+            <button id="save-test" style="display: none;" class="btn btn-large">Save</button>
+          </div>
+
         </div>
       </div>
     </div>
 
     <!-- Javascript -->
     <script src="node_modules/handsontable/dist/handsontable.full.js"></script>
+    <script src="node_modules/codemirror/lib/codemirror.js"></script>
+    <script src="node_modules/codemirror/mode/javascript/javascript.js"></script>
     <script src="js/renderer.js"></script>
     <script src="js/controller.js"></script>
 

--- a/electron/js/controller.js
+++ b/electron/js/controller.js
@@ -88,7 +88,7 @@ function deleteTest(test) {
 
 function duplicateTest(test) {
   var newTest = {
-    name: test.name(),
+    name: test.name() + " copy",
     description: test.description(),
     filename: uuid.v1(),
     local: true,

--- a/electron/js/controller.js
+++ b/electron/js/controller.js
@@ -170,6 +170,15 @@ function renderStep2(processorConfig) {
     html += d.description() || ""
     return html
   })
+  .on("click", function(d) {
+    console.log("TEST", d)
+    renderTestEditor({
+      name: d.name(),
+      description: d.description(),
+      code: d._methodology.toString()
+    })
+  })
+
   tests.select('label')
     .on("click", function(d) {
       console.log("test", d)
@@ -242,7 +251,6 @@ function handleFileSelect(evt) {
   reader.readAsText(file);
 }
 
-// if we receive a saved file we load it
 ipc.on("last-file-selected", function(event, file) {
   //console.log("last file selected was", file)
   lastProcessorConfig = {
@@ -252,12 +260,13 @@ ipc.on("last-file-selected", function(event, file) {
     renderer: HTMLRenderer,
     input: {}
   }
-
+  loadLastFile();
 })
 function loadLastFile() {
   renderStep1(lastProcessorConfig);
-  renderStep2(lastProcessorConfig);
-  currentStep = 3;
+  currentStep = 2;
+  //renderStep2(lastProcessorConfig);
+  //currentStep = 3;
   renderNav();
   renderCurrentStep();
 }
@@ -327,6 +336,62 @@ function handleSpreadsheet() {
     }
   }
 };
+
+var testEditor = d3.select(".test-editor")
+testEditor.style("display", "none")
+
+d3.select("#cancel-test").on("click", function() {
+  testEditor.style("display", "none")
+})
+// setup CodeMirror editor
+function renderTestEditor(test) {
+  testEditor.select("#test-editor-js").selectAll("*").remove();
+
+  testEditor.style("display", "block")
+  var nameInput = d3.select("#test-editor-name")
+  nameInput.node().value = test.name;
+
+  var descriptionInput = d3.select("#test-editor-description")
+  descriptionInput.node().value = test.description;
+
+  codeMirror = window.CodeMirror(d3.select("#test-editor-js").node(), {
+    tabSize: 2,
+    value: test.code,
+    mode: 'javascript',
+    htmlMode: true,
+    lineNumbers: true,
+    theme: 'mdn-like',
+    lineWrapping: true,
+    matchBrackets: true,
+    autoCloseBrackets: true,
+    extraKeys: {
+      'Cmd-/' : 'toggleComment',
+      'Ctrl-/' : 'toggleComment'
+    },
+    viewportMargin: Infinity
+  });
+
+  function save() {
+    var test = {
+      name: nameInput.node().value,
+      description: descriptionInput.node().value,
+      code: codeMirror.getValue()
+    }
+    console.log("save!", test)
+  }
+  var saveTest = d3.select("#save-test")
+  saveTest.on("click", save)
+  if(test.local) {
+    saveTest.style("display", "block")
+  }
+
+  /*
+  nameInput.on("change", save)
+  descriptionInput.on("change", save)
+  codeMirror.on("change", save)
+  */
+}
+
 
 // Enable context menu
 // http://stackoverflow.com/questions/32636750/how-to-add-a-right-click-menu-in-electron-that-has-inspect-element-option-like

--- a/electron/js/renderer.js
+++ b/electron/js/renderer.js
@@ -69,7 +69,7 @@ HTMLRenderer.prototype.constructor = HTMLRenderer;
 
 HTMLRenderer.prototype.addResult = function(suite, test, result) {
   //console.log("add result", suite, test.name(), result)
-  this.resultList[suite].push({ suite: suite, test: test, result: result })
+  this.resultList[suite].push({ suite: suite, test: test, result: result || {} })
 
   // setup/update the comments
   var columnHeads = this.columnHeads;

--- a/electron/package.json
+++ b/electron/package.json
@@ -17,6 +17,7 @@
     "codemirror": "^5.13.2",
     "d3": "^3.5.12",
     "dataproofer": "file:../src/",
+    "dataproofertest": "git://github.com/dataproofer/dataproofertest.js.git",
     "dataproofer-core-suite": "git://github.com/dataproofer/core-suite.git",
     "dataproofer-geo-suite": "git://github.com/dataproofer/geo-suite.git",
     "dataproofer-info-suite": "git://github.com/dataproofer/info-suite.git",
@@ -27,7 +28,10 @@
     "handsontable": "^0.24.1",
     "jquery": "^2.2.0",
     "lodash": "^4.0.0",
-    "slickgrid": "^2.1.0"
+    "require-from-string": "^1.1.0",
+    "simple-statistics": "^1.0.1",
+    "slickgrid": "^2.1.0",
+    "uuid": "^2.0.1"
   },
   "devDependencies": {
     "electron-packager": "^5.2.1"

--- a/electron/package.json
+++ b/electron/package.json
@@ -14,6 +14,7 @@
     "url": "git+https://github.com/dataproofer/dataproofer.git"
   },
   "dependencies": {
+    "codemirror": "^5.13.2",
     "d3": "^3.5.12",
     "dataproofer": "file:../src/",
     "dataproofer-core-suite": "git://github.com/dataproofer/core-suite.git",


### PR DESCRIPTION
**Summary**
Allow users to copy tests into a locally stored file. They can then rename/edit the code of those tests, or delete them. They run in their own suite, which is always shown at the top.

**Proposed changes**

Provide a few more details like what files were modified, added or removed.

* What was modified:
* What was added:  
  mostly added a function to render the code in controller.js, also added some logic for loading and saving test code in files in app.js
* What was removed:
* Next actions:

@dataproofer/core
