### PR TITLE
Update & fix Google Sheets logic

### DIFF
--- a/electron/js/controller.js
+++ b/electron/js/controller.js
@@ -250,7 +250,6 @@ function renderStep2(processorConfig) {
   var filteredSuites = _.filter(processorConfig.suites, function(suite) {
     return suite.tests.length > 0;
   });
-  console.log("suites", processorConfig.suites);
   var suites = container.selectAll(".suite")
     .data(filteredSuites);
 
@@ -411,14 +410,12 @@ function renderStep2(processorConfig) {
 function renderStep3(processorConfig) {
   if (renderer) renderer.destroy();
   renderer = Processor.run(processorConfig);
-  console.log("renderer", renderer);
   d3.select(".step-3-results").style("display", "block")
     .insert("div", ":first-child")
     .html(function() {
       var headersCheck = renderer.resultList[0];
       var missingHeadersStr = "";
       if (!headersCheck.result.passed) {
-        console.log("headers check", headersCheck);
         missingHeadersStr += "<div class='info'>";
         missingHeadersStr += "<i class='fa fa-exclamation-triangle'></i>";
         missingHeadersStr += " Ignored ";
@@ -595,18 +592,34 @@ function handleSpreadsheet() {
     // console.log(sheet);
     if (err) {
       handleGsheetsError(err);
-      alert(err);
+      console.log(err);
     } else if (sheet) {
       //console.log("sheet", sheet);
-      var column_names = Object.keys(sheet.data[0]);
+      var columnHeads = Object.keys(sheet.data[0]);
+      console.log("sheet", sheet);
+      var rows = sheet.data;
+      var trueRows = rows.length;
+      if (trueRows > 1000) {
+        rows = _.sampleSize(rows, 1000);
+      }
       var config = {
+        title: sheet.title,
+        updated: sheet.updated
+      }
+      var loaded = {
+        rows: rows,
+        columnHeads: columnHeads,
+        trueRows: trueRows,
+        config: config
+      };
+      var processorConfig = {
         filename: sheet.title,
-        columnsHeads: column_names,
-        rows: sheet.data,
         suites: SUITES,
         renderer: HTMLRenderer,
+        loaded: loaded,
         input: {}
       };
+      lastProcessorConfig = processorConfig;
       renderStep1(config);
       currentStep = 2;
       renderCurrentStep();

--- a/src/processing.js
+++ b/src/processing.js
@@ -43,7 +43,9 @@ exports.load = function(config) {
 
   // TODO: use webworkers or something so we don't need an upper limit
   var trueRows = rows.length;
-  rows = _.sampleSize(rows, 1000);
+  if (trueRows > 1000) {
+    rows = _.sampleSize(rows, 1000);
+  }
 
   return {
     rows: rows,


### PR DESCRIPTION
Fixes #84 

**Summary**
Make sure processor knows `trueRows` for Google Spreadsheets so we have a max cutoff. Renderer now requires this info so it can alert users if we need to take a smaller sample of their data.

**Proposed changes**

* What was modified: controller.js passes more info to the processor. processing only gets a sample if the true rows are above 1000
* Next actions:
  * update project with `./update.sh`
  * @ejfox tests and confirms this PR works