### PR TITLE
Made the gsheet error handler more readable

### DIFF
--- a/electron/js/controller.js
+++ b/electron/js/controller.js
@@ -617,7 +617,9 @@ function handleSpreadsheet() {
   gsheets.getWorksheetById(gid, "od6", process);
 
   function handleGsheetsError(err) {
-    alert(err.toString());
+    var message = "There was an error downloading the spreadsheet from Google. \
+Please make sure it is shared to public.\n\nDetails:\n" + err.toString();
+    alert(message);
   }
 
   function process(err, sheet) {


### PR DESCRIPTION
Fixes #137 

**Summary**

Adds a human readable error message. We can always add more instructions for helping people debug later.

Old google sheets fetch error alert:
<img width="772" alt="screen shot 2016-10-30 at 4 40 28 pm" src="https://cloud.githubusercontent.com/assets/1542740/19838097/a1609694-9ebf-11e6-9a88-9e1997efe8a7.png">
Proposed google sheets fetch error alert:
<img width="695" alt="screen shot 2016-10-30 at 4 40 47 pm" src="https://cloud.githubusercontent.com/assets/1542740/19838098/a3bd4da6-9ebf-11e6-98bc-32342b90f2df.png">
