### PR TITLE
Use v4 instead of v1 uuids

### DIFF
--- a/electron/app.js
+++ b/electron/app.js
@@ -2,7 +2,7 @@ const {app, BrowserWindow, Menu, ipcMain} = require("electron");
 // Module to control application life.
 // Module to create native browser window.
 var defaultMenu = require("electron-default-menu");
-var uuid = require("uuid");
+var uuidV4 = require("uuid/v4");
 // We can listen to messages from the renderer here:
 var fs = require("fs");
 
@@ -126,7 +126,7 @@ function createWindow() {
       var filename = test.filename;
       if(!filename) {
         // we need to create a filename
-        filename = uuid.v1();
+        filename = uuidV4();
       }
       fs.writeFile(savedTestsStorage + "/" + filename, JSON.stringify(test));
     });

--- a/electron/js/controller.js
+++ b/electron/js/controller.js
@@ -9,7 +9,7 @@ var ipc = require("electron").ipcRenderer;
 // libraries required to run test inline
 // var requireFromString = require("require-from-string");
 var DataprooferTest = require("dataproofertest-js");
-var uuid = require("uuid");
+var uuidV4 = require("uuid/v4");
 
 console.log("dataproofer app version", require("./package.json").version);
 console.log("dataproofer lib version", require("dataproofer").version);
@@ -84,7 +84,7 @@ function duplicateTest(test) {
   var newTest = {
     name: test.name() + " copy",
     description: test.description(),
-    filename: uuid.v1(),
+    filename: uuidV4(),
     local: true,
     active: true,
     methodology: test._methodology.toString()
@@ -689,7 +689,7 @@ function renderTestEditor(test) {
       // saving without passing in the filename will inform the server
       // to generate a new filename
       /*
-    var newTestFile = save(uuid.v1());
+    var newTestFile = save(uuidV4());
     var newTest = loadTest(newTestFile);
     SUITES[0].tests.push(newTest); // assuming the first suite is always local
     renderCurrentStep(); // we should only be here on step 2

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -1075,6 +1075,11 @@
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
           }
+        },
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
         }
       }
     },
@@ -4920,9 +4925,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/electron/package.json
+++ b/electron/package.json
@@ -33,7 +33,7 @@
     "simple-statistics": "^1.0.1",
     "tipsy": "^1.0.0",
     "tipsy-browserify": "^1.0.0",
-    "uuid": "^2.0.1"
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.2",


### PR DESCRIPTION
**Summary**

I'm a co-author of the [uuid npm module](https://github.com/kelektiv/node-uuid) which is being used in some places within this code base.

I'm currently trying to understand real-world use cases of [time-based UUIDs ("v1 UUIDs")](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_1_(date-time_and_MAC_address)).

**Proposed changes**

I found two occurrence where `v1` UUIDs were being used instead of `v4` UUIDs and I was wondering if these cases really require the semantically much more complex `v1` UUIDs or whether we could live equally well with purely random `v4` UUIDs? Please see my commit messages for more details.

I'd be really curious to understand the motivation for choosing `v1` over `v4` UUIDs in the first place, so any feedback on this would be highly appreciated!

@enjalot as far as I can tell from the git history (10f9bef1591fd55f4626c1a7ac6492eaa54164f0) it seems like you have introduced the `v1` UUIDs so I'd be particularly interested in your feedback.

@dataproofer/core
