### PR TITLE
Fix: cleanup json output to be machine-readable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -235,24 +235,23 @@ if (require.main === module) {
 
       let exit = program.opts().exit && totalFailed > 0;
       var done = function () {
-        process.stdout.write(summaryStr);
-        process.stdout.write("\n### PROOFED ###\n\n");
+        if (!program.opts().json || program.opts().jsonPretty) {
+          process.stdout.write(summaryStr);
+          process.stdout.write("\n### PROOFED ###\n\n");
+        }
         if (exit) process.exit(1);
+        return;
       };
 
       var outPath = program.opts().out ? program.opts().out : "/dev/stdout";
 
       if (program.opts().out) resultStr = resultStr.replace(/\[\d+m/g, "");
       if (program.opts().json === true) {
-        rw.writeFile(outPath, JSON.stringify(results), () => {
-          if (exit) process.exit(1);
-        });
+        rw.writeFile(outPath, JSON.stringify(results), done);
         return;
       }
       if (program.opts().jsonPretty === true) {
-        rw.writeFile(outPath, JSON.stringify(results, null, 2), () => {
-          if (exit) process.exit(1);
-        });
+        rw.writeFile(outPath, JSON.stringify(results, null, 2), done);
         return;
       }
       if (program.opts().summary !== true) {

--- a/src/index.js
+++ b/src/index.js
@@ -47,8 +47,8 @@ if (require.main === module) {
     )
     .option("-v, --verbose", "include descriptions about each column")
     .option(
-      "-e, --error",
-      "throw an error to the console if any tests fail (useful for CI)"
+      "-e, --exit",
+      "exit with a console error if any tests fail (useful for CI)"
     )
     .option("-x, --exclude", "exclude tests that passed")
     .option(

--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,7 @@ if (require.main === module) {
       suites: SUITES,
       renderer: Rendering,
       loaded: loaded,
+      json: program.opts().json || program.opts().jsonPretty,
     };
     Processing.run(processorConfig).then(function (processor) {
       const { results } = processor;
@@ -225,10 +226,10 @@ if (require.main === module) {
         );
         return;
       }
-      process.stdout.write(summaryStr);
 
       var done = function () {
-        process.stdout.write("\n### DONE ###\n\n");
+        process.stdout.write(summaryStr);
+        process.stdout.write("\n### PROOFED ###\n\n");
       };
 
       var outPath = program.opts().out ? program.opts().out : "/dev/stdout";
@@ -236,12 +237,10 @@ if (require.main === module) {
       if (program.opts().out) resultStr = resultStr.replace(/\[\d+m/g, "");
       if (program.opts().json === true) {
         rw.writeFileSync(outPath, JSON.stringify(results), "utf-8");
-        done();
         return;
       }
       if (program.opts().jsonPretty === true) {
         rw.writeFileSync(outPath, JSON.stringify(results, null, 2), "utf-8");
-        done();
         return;
       }
       if (program.opts().summary !== true) {

--- a/src/index.js
+++ b/src/index.js
@@ -233,7 +233,7 @@ if (require.main === module) {
         return;
       }
 
-      let exit = program.opts().error && totalFailed > 0;
+      let exit = program.opts().exit && totalFailed > 0;
       var done = function () {
         process.stdout.write(summaryStr);
         process.stdout.write("\n### PROOFED ###\n\n");
@@ -257,7 +257,6 @@ if (require.main === module) {
       }
       if (program.opts().summary !== true) {
         rw.writeFile(outPath, resultStr, done);
-        return;
       } else {
         done();
       }

--- a/src/processing.js
+++ b/src/processing.js
@@ -20,9 +20,6 @@ Processor.prototype = {
 
     var sampleSize = Math.round(sampleRatio * totalRows);
 
-    console.info("\ntotal rows", totalRows);
-    console.info("rows sampled", sampleSize);
-
     if (sampleSize < 1000 && totalRows < 1000) {
       // test all the rows if there's less than a thousand in total
       sampleSize = totalRows;
@@ -119,6 +116,7 @@ Processor.prototype = {
       rows: rows,
       sampleProgress: sampleProgress,
       totalRows: totalRows,
+      json: config.json,
     });
 
     var badColumnHeadsTest = new DataprooferTest()

--- a/src/rendering.js
+++ b/src/rendering.js
@@ -5,6 +5,7 @@
  * @return {undefined}
  */
 function Renderer(config) {
+  Object.assign(this, config);
   var results = (this.results = {});
   config.suites.forEach(function (suite) {
     // console.log("suite name", suite);
@@ -49,7 +50,10 @@ Renderer.prototype.addError = function (suite, test, error) {
  */
 Renderer.prototype.done = function () {
   // finish up
-  process.stdout.write("\n### PROOFED ###\n");
+  if (!this.json) {
+    console.info("\ntotal rows", this.totalRows);
+    console.info("rows sampled", this.rows.length);
+  }
 };
 
 module.exports = Renderer;


### PR DESCRIPTION
## Summary

This change accomplishes both a fix and provides a new feature. The initial v2 made the JSON output unable to be read by machines, specifically command-line tools like `jq`.

### Changes

* Moves contextual info, e.g. the number of tests passed and the number of rows sampled, behind conditionals. If you're outputting JSON `--json` or `--json-pretty` then these contextual strings are not output.
* Converts WriteFileSync to WriteFile streams, allowing for CLI pipe `|` functionality, e.g. `| jq`

### Addtions

* Adds a new flag `--exit` or `-e` to throw a CLI error if any Dataproofer tests are total failures. This allows for developers to creates automated CI workflows like GitHub Actions that can throw errors and notify others if a dataset has serious problems.

## How to review

* Pull this branch
* Try out the sample datasets with `jq` queries. Maybe add some `jq` documentation?
* Run Dataproofer with the new `--exit` flag. Does it throw errors in your console :x: